### PR TITLE
Fix mistake in vignette

### DIFF
--- a/vignettes/dams.Rmd
+++ b/vignettes/dams.Rmd
@@ -111,8 +111,8 @@ gfx_map <- gfx_map + geom_polygon(aes(x = long, y = lat, group = group,
             fill = dams))
 gfx_map <- gfx_map + geom_path(data = geo_state, aes(x = long, y = lat,
             group = group, fill = NA))
-gfx_map <- gfx_map + labs(list(title = "Number of Dams in the NID Database",
-            x = NULL, y = NULL))
+gfx_map <- gfx_map + labs(title = "Number of Dams in the NID Database",
+            x = NULL, y = NULL)
 gfx_map <- gfx_map + guides(fill = guide_legend(title = "Number of Dams"))
 gfx_map <- gfx_map + scale_fill_brewer(palette = "Accent")
 gfx_map <- gfx_map + coord_map()


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
Essentially, in the vignette, the `labs()` function was used incorrectly, which this PR rectifies.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time or let us know when ggplot2 should change. Hopefully this will inform you in a timely manner.

Best wishes,
Teun
